### PR TITLE
Filter out strings with uri encoded characters

### DIFF
--- a/config/excluded_filetypes.json
+++ b/config/excluded_filetypes.json
@@ -1,19 +1,20 @@
 {
   "audio": ["aif", "cda", "mid", "mp3", "mpa", "ogg", "wav", "wma", "wpl", "dts", "ac3"],
-  "video": ["3g2", "3gp", "avi", "flv", "h264", "h265", "m4v", "mkv", "mov", "mp4", "mpg", "mpeg", "rm", "swf", "vob", "wmv"],
+  "video": ["3g2", "3gp", "avi", "flv", "h264", "h265", "m4v", "mkv", "mov", "mp4", "mpg", "mpeg", "rm", "swf", "vob", "wmv", "webm"],
   "image": ["ai", "bmp", "gif", "ico", "jpeg", "jpg", "png", "ps", "psd", "svg", "tif", "tiff", "icns"],
   "compressed": ["7z", "arj", "pkg", "rar", "rpm", "gz", "z", "zip", "tar.gz", "tar", "bz2", "whl", "phar"],
   "font": ["otf", "ttf", "woff", "woff2", "eot"],
   "document": ["pdf", "doc", "docx", "xls", "xlsx", "ppt", "pptx", "txt", "rtf", "asciidoc"],
-  "binary": ["o", "exe", "dmg", "deb", "msi", "node", "bin", "s", "so", "so.0", "jar", "war", "har", "hqx", "sa", "asm", "nasm", "a51", "syso"],
-  "other": ["log", "sql", "map", "xml", "lock", "gitignore", "example", "torrent", "nsi", "tmp", "terminal", "patch", "license", "pbxproj", "git", "dump"],
+  "binary": ["o", "exe", "dmg", "deb", "msi", "node", "bin", "s", "so", "so.0", "jar", "war", "har", "hqx", "sa", "asm", "nasm", "a51", "syso", "xbf"],
+  "other": ["log", "sql", "map", "xml", "lock", "gitignore", "example", "torrent", "nsi", "tmp", "terminal", "patch", "license", "pbxproj", "git", "dump", "ini"],
   "translation": ["po", "pot", "qm"],
   "email": ["eml", "msg"],
   "minified-code": ["min.js", "min.css", "min.json"],
-  "stylesheet": ["css", "scss", "less", "sass"],
+  "stylesheet": ["css", "scss", "less", "sass", "jss"],
   "build": ["pb.cc", "pb.h", "build", "makefile", "make", "mak", "cmake", "nmake", "ll"],
   "crypto": ["sha1"],
   "ocaml": ["dot"],
   "go": ["sum"],
-  "typescript": ["d.ts", "tsbuildinfo"]
+  "typescript": ["d.ts", "tsbuildinfo"],
+  "web": ["vtt", "rss", "mht", "xslt", "shtm", "atom"]
 }

--- a/config/included_filetypes.json
+++ b/config/included_filetypes.json
@@ -82,6 +82,7 @@
   "html": [
     "html",
     "xhtml",
+    "xht",
     "htm"
   ],
   "julia": [

--- a/src/filters/enumerated_charset.js
+++ b/src/filters/enumerated_charset.js
@@ -7,6 +7,8 @@ class EnumeratedCharset extends Filter {
 
   isMatch(term) {
     return term.includes('123456789')
+        || term.includes('123456')
+        || term.includes('456789')
         || term.includes('abcdefghijklmnopqrstuvwxyz')
         || term.includes('abcdef')
         || term.includes('defghi')

--- a/src/filters/hex_notation.js
+++ b/src/filters/hex_notation.js
@@ -1,0 +1,17 @@
+const Filter = require('../objects/Filter');
+
+class HexNotation extends Filter {
+  constructor() {
+    super('Hex Notation');
+
+    // case-sensitive, 0x should always be lowercase
+    this.hexNotation = /0x[a-fA-F0-9]/;
+  }
+
+  isMatch(term) {
+    return this.hexNotation.test(term);
+  }
+}
+
+const filter = new HexNotation();
+module.exports = filter;

--- a/src/filters/repeating_characters.js
+++ b/src/filters/repeating_characters.js
@@ -12,6 +12,9 @@ class RepeatingCharacters extends Filter {
     if (term.includes("!!!"))
       return true;
 
+    if (term.startsWith("//"))
+      return true;
+
     if (((term.match(/=/g) || []).length >= 3) && (!term.includes("==")))
       return true;
 

--- a/src/filters/uri_encoding.js
+++ b/src/filters/uri_encoding.js
@@ -1,0 +1,18 @@
+const Filter = require('../objects/Filter');
+
+class URIEncoding extends Filter {
+  constructor() {
+    super('URI Encoding');
+
+    this.encodedCharacterRegex = /%[a-f0-9]{2}/ig;
+  }
+
+  isMatch(term) {
+    const encodedCharacters = term.match(this.encodedCharacterRegex);
+    // require at least 2 encoded characters
+    return (encodedCharacters !== null) && (encodedCharacters.length >= 2);
+  }
+}
+
+const filter = new URIEncoding();
+module.exports = filter;

--- a/src/secrets/api_keys.js
+++ b/src/secrets/api_keys.js
@@ -8,6 +8,7 @@ class APIKeys extends Secret {
     const name = 'api_key';
     const preFilters = [
       'uri_encoding',
+      'hex_notation',
       'xml',
       'common_patterns',
       'date',

--- a/src/secrets/api_keys.js
+++ b/src/secrets/api_keys.js
@@ -116,9 +116,17 @@ class APIKeys extends Secret {
       return false;
     }
 
-    const isTermAlphaNumeric = /^[a-z0-9]+$/i.test(term);
-    return (term.length >= this.minTermLength)
-      || (isTermAlphaNumeric && (term.length >= this.minAlphaNumericTermLength) && (term.length % 4 === 0));
+    if (term.length >= this.minTermLength) {
+      return true;
+    }
+
+    const alphaNumericTerms = term.match(/[a-z0-9]+/ig);
+    if (alphaNumericTerms === null) {
+      return false;
+    }
+
+    const termsOfValidLength = alphaNumericTerms.filter(t => (t.length >= this.minAlphaNumericTermLength) && (t.length % 4 === 0));
+    return termsOfValidLength.length > 0;
   }
 }
 

--- a/src/secrets/api_keys.js
+++ b/src/secrets/api_keys.js
@@ -78,7 +78,6 @@ class APIKeys extends Secret {
       .trim()
       .split(/ +/)
       .filter(term => this.isValidTermLength(term))
-      .filter(term => !term.endsWith('.com'))
       .filter(term => this.isAlphaNumeric(term));
   }
 

--- a/src/secrets/api_keys.js
+++ b/src/secrets/api_keys.js
@@ -77,21 +77,23 @@ class APIKeys extends Secret {
       .split(/ +/)
       .filter(term => this.isValidTermLength(term))
       .filter(term => !term.endsWith('.com'))
-      .filter((term) => {
-        const containsLetters = term.match(this.lettersRegex);
-        // require 3 or more letters numbers to help reduce false positives
-        if ((containsLetters === null) || (new Set(containsLetters).size < 3)) {
-          return false;
-        }
+      .filter(term => this.isAlphaNumeric(term));
+  }
 
-        const containsNumbers = term.match(this.numbersRegex);
-        // require 3 or more distinct numbers to help reduce false positives
-        if ((containsNumbers === null) || (new Set(containsNumbers).size < 3)) {
-          return false;
-        }
+  isAlphaNumeric(term) {
+    const containsLetters = term.match(this.lettersRegex);
+    // require 3 or more letters numbers to help reduce false positives
+    if ((containsLetters === null) || (new Set(containsLetters).size < 3)) {
+      return false;
+    }
 
-        return true;
-      });
+    const containsNumbers = term.match(this.numbersRegex);
+    // require 3 or more distinct numbers to help reduce false positives
+    if ((containsNumbers === null) || (new Set(containsNumbers).size < 3)) {
+      return false;
+    }
+
+    return true;
   }
 
   static isValidCharacter(char) {
@@ -107,9 +109,9 @@ class APIKeys extends Secret {
       return false;
     }
 
-    const isAlphaNumeric = /^[a-z0-9]+$/i.test(term);
+    const isTermAlphaNumeric = /^[a-z0-9]+$/i.test(term);
     return (term.length >= this.minTermLength)
-      || (isAlphaNumeric && (term.length >= this.minAlphaNumericTermLength) && (term.length % 4 === 0));
+      || (isTermAlphaNumeric && (term.length >= this.minAlphaNumericTermLength) && (term.length % 4 === 0));
   }
 }
 

--- a/src/secrets/api_keys.js
+++ b/src/secrets/api_keys.js
@@ -89,8 +89,8 @@ class APIKeys extends Secret {
     }
 
     const groupsOfLetters = term.match(this.groupsOfLettersRegex);
-    // require more than one group of numbers
-    if ((groupsOfLetters === null) || (groupsOfLetters.length < 2)) {
+    // require 3 or more groups of numbers
+    if ((groupsOfLetters === null) || (groupsOfLetters.length < 3)) {
       return false;
     }
 

--- a/src/secrets/api_keys.js
+++ b/src/secrets/api_keys.js
@@ -33,6 +33,7 @@ class APIKeys extends Secret {
     this.charactersToReplace = /(\||"|'|;|\\|\(\)|{}|(->))+/g;
     this.variableNameRegex = (/^([a-zA-Z0-9]{2,}_)+([a-zA-Z0-9]){2,}(=|:)/);
     this.lettersRegex = /[a-z]/ig;
+    this.groupsOfLettersRegex = /[a-z]+/ig;
     this.numbersRegex = /[0-9]/g;
 
     this.minAlphaNumericTermLength = 24;
@@ -84,6 +85,12 @@ class APIKeys extends Secret {
     const containsLetters = term.match(this.lettersRegex);
     // require 3 or more letters numbers to help reduce false positives
     if ((containsLetters === null) || (new Set(containsLetters).size < 3)) {
+      return false;
+    }
+
+    const groupsOfLetters = term.match(this.groupsOfLettersRegex);
+    // require more than one group of numbers
+    if ((groupsOfLetters === null) || (groupsOfLetters.length < 2)) {
       return false;
     }
 

--- a/src/secrets/api_keys.js
+++ b/src/secrets/api_keys.js
@@ -7,6 +7,7 @@ class APIKeys extends Secret {
   constructor() {
     const name = 'api_key';
     const preFilters = [
+      'uri_encoding',
       'xml',
       'common_patterns',
       'date',

--- a/src/secrets/api_keys.js
+++ b/src/secrets/api_keys.js
@@ -34,7 +34,7 @@ class APIKeys extends Secret {
     this.charactersToReplace = /(\||"|'|;|\\|\(\)|{}|(->))+/g;
     this.variableNameRegex = (/^([a-zA-Z0-9]{2,}_)+([a-zA-Z0-9]){2,}(=|:)/);
     this.lettersRegex = /[a-z]/ig;
-    this.groupsOfLettersRegex = /[a-z]+/ig;
+    this.groupsOfNumbersRegex = /[0-9]+/ig;
     this.numbersRegex = /[0-9]/g;
 
     this.minAlphaNumericTermLength = 24;
@@ -88,9 +88,9 @@ class APIKeys extends Secret {
       return false;
     }
 
-    const groupsOfLetters = term.match(this.groupsOfLettersRegex);
+    const groupsOfNumbers = term.match(this.groupsOfNumbersRegex);
     // require 3 or more groups of numbers
-    if ((groupsOfLetters === null) || (groupsOfLetters.length < 3)) {
+    if ((groupsOfNumbers === null) || (groupsOfNumbers.length < 3)) {
       return false;
     }
 

--- a/test/filters/hex_notation.test.js
+++ b/test/filters/hex_notation.test.js
@@ -1,0 +1,10 @@
+const Filter = require('../../src/filters/hex_notation');
+
+test('hex notation', () => {
+  expect(Filter.isMatch("0xab96")).toBe(true);
+  expect(Filter.isMatch("0xAB96")).toBe(true);
+
+  expect(Filter.isMatch("0x")).toBe(false);
+  expect(Filter.isMatch("0xg")).toBe(false);
+  expect(Filter.isMatch("0Xab96")).toBe(false);
+});

--- a/test/filters/uri_encoding.test.js
+++ b/test/filters/uri_encoding.test.js
@@ -1,0 +1,9 @@
+const Filter = require('../../src/filters/uri_encoding');
+
+test('uri encoding', () => {
+  expect(Filter.isMatch("")).toBe(false);
+  expect(Filter.isMatch("test")).toBe(false);
+  expect(Filter.isMatch("test%20")).toBe(false);
+  expect(Filter.isMatch("test%20%20")).toBe(true);
+  expect(Filter.isMatch("test%20%21")).toBe(true);
+});

--- a/test/secrets/api_keys.test.js
+++ b/test/secrets/api_keys.test.js
@@ -1,0 +1,13 @@
+const APIKeys = require('../../src/secrets/api_keys');
+const FileTags = require('../../src/objects/file_tags');
+
+test('should scan', () => {
+  expect(APIKeys.shouldScan(new Set([]))).toBe(true);
+  expect(APIKeys.shouldScan(new Set([FileTags.README]))).toBe(true);
+  expect(APIKeys.shouldScan(new Set([FileTags.README, FileTags.NO_EXTENSION]))).toBe(true);
+
+  expect(APIKeys.shouldScan(new Set([FileTags.CRYPTO_PRIVATE_KEY]))).toBe(false);
+  expect(APIKeys.shouldScan(new Set([FileTags.CRYPTO_PUBLIC_KEY]))).toBe(false);
+  expect(APIKeys.shouldScan(new Set([FileTags.NO_EXTENSION]))).toBe(false);
+  expect(APIKeys.shouldScan(new Set([FileTags.ENV_FILE]))).toBe(false);
+});


### PR DESCRIPTION
- Filter out strings with uri encoded characters
- Require api key to have more than 1 group of numbers
- Filter out terms starting with '//'